### PR TITLE
Fixed segfault if invalid flag is provided

### DIFF
--- a/main.c
+++ b/main.c
@@ -559,10 +559,10 @@ int main(int argc, char** argv)
         }
     }
 
-	if (flag_type >= FLAG_TYPE_END) {
-		fprintf(stderr, "Invalid flag: %d\n", flag_type);
-		exit(1);
-	}
+    if (flag_type >= FLAG_TYPE_END) {
+        fprintf(stderr, "Invalid flag: %d\n", flag_type);
+        exit(1);
+    }
 
     /* Handle randomness. */
     int rand_offset = 0;

--- a/main.c
+++ b/main.c
@@ -559,7 +559,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (flag_type >= FLAG_TYPE_END) {
+    if (flag_type <= FLAG_TYPE_INVALID || flag_type >= FLAG_TYPE_END) {
         fprintf(stderr, "Invalid flag: %d\n", flag_type);
         exit(1);
     }

--- a/main.c
+++ b/main.c
@@ -559,6 +559,11 @@ int main(int argc, char** argv)
         }
     }
 
+	if (flag_type >= FLAG_TYPE_END) {
+		fprintf(stderr, "Invalid flag: %d\n", flag_type);
+		exit(1);
+	}
+
     /* Handle randomness. */
     int rand_offset = 0;
     if (random) {


### PR DESCRIPTION
If a flag that is out of range (aka further than FLAG_TYPE_END) is provided, the app will just be ended with a segfault instead of properly reporting the error, this PR fixes it.