### PR TITLE
Flag data refactor (part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ With no FILE, or when FILE is -, read standard input.
                          --version: Print version and exit  
                             --help: Show this message
 ```
+(Flag list above may not be up to date; run `queercat --help` to see which flags your version supports!)
 
 ## Adding a flag
 ### Step 1: Define the pattern
@@ -53,24 +54,10 @@ Example:
 };
 ```
 
-### Step 2: Add in the `README.md` and help string.
+### Step 2 (optional): Update `README.md` to include your addition.
 **Pay attention to the number it gets from its position in the array!**
 
-`main.c`
-``` c
-/* *** Constants *****************************************************/
-static char helpstr[] = "\n"
-                        ...
-                        "--flag <d>                , -f <d>: Choose colors to use:\n"
-                        "                                    [rainbow: 0, trans: 1, NB: 2, lesbian: 3, \n"
-                        "                                    gay: 4, pan: 5, bi: 6, genderfluid: 7, asexual: 8, \n"
-                        "                                    your_new_flag: 9]\n"
-                        "                                    default is rainbow (0)\n"
-                        ...
-```
-
-`README.md`
-Extend the line for `--flag` under `Usage` the same way as in the `main.c`.
+Extend the line for `--flag` under `Usage`.
 
 *Note that in the readme it is a single line.*
 

--- a/README.md
+++ b/README.md
@@ -53,26 +53,8 @@ Example:
 };
 ```
 
-### Step 2: Add to the enum
-Next, add a new value at the end of the enum `flag_type_t` (just before `FLAG_TYPE_END`). If you've added more than
-new flag, be sure their order here matches their order in the `flags` array!
-
-``` c
-/* Patterns enum. */
-typedef enum flag_type_e
-{
-    FLAG_TYPE_INVALID = -1,
-    FLAG_TYPE_RAINBOW = 0,
-    FLAG_TYPE_TRANS,
-    ...
-    FLAG_TYPE_ASEXUAL,
-    /* FLAG_TYPE_YOUR_NEW_FLAG goes here. */
-    FLAG_TYPE_END
-} flag_type_t;
-```
-
-### Step 3: Add in the `README.md` and help string.
-**Pay attention to the number it gets from the enum!**
+### Step 2: Add in the `README.md` and help string.
+**Pay attention to the number it gets from its position in the array!**
 
 `main.c`
 ``` c
@@ -92,7 +74,7 @@ Extend the line for `--flag` under `Usage` the same way as in the `main.c`.
 
 *Note that in the readme it is a single line.*
 
-### Step 4: Pull request :)
+### Step 3: Pull request :)
 
 ## Compiling
 to compile with gcc: `$ gcc main.c -lm -o queercat`  

--- a/README.md
+++ b/README.md
@@ -22,33 +22,41 @@ With no FILE, or when FILE is -, read standard input.
 
 ## Adding a flag
 ### Step 1: Define the pattern
-To add a flag, first create an instance of `pattern_t` for it in the `main.c` file.  
-under the section `/* *** Flags *********************************************************/`
+To add a flag, first add an instance of `pattern_t` for it to the `flags` array in the `main.c` file.
+Look for the section `/* *** Flags *********************************************************/`, then find
+`/* Add new flags above this line. */`. The order is important! For the sake of simplicity, you should
+only add to the end.
 
 Example:
 ``` c
-const pattern_t nonbinary = {
-    .name = "nonbinary",
-    .ansii_pattern = {
-        .codes_count = 8,
-        .ansii_codes = {226, 226, 255, 255, 93, 93, 234, 234}
     },
-    .color_pattern = {
-        .stripes_count = 4,
-        .stripes_colors = {
-            0xffff00, /* #ffff00 - Yellow */
-            0xb000ff, /* #b000ff - Purple */
-            0xffffff, /* #ffffff - White */
-            0x000000  /* #000000 - Black */
-        },
-        .factor = 4.0f
+
+    {
+        .name = "nonbinary",
+            .ansii_pattern = {
+                .codes_count = 8,
+                .ansii_codes = {226, 226, 255, 255, 93, 93, 234, 234}
+            },
+            .color_pattern = {
+                .stripes_count = 4,
+                .stripes_colors = {
+                    0xffff00, /* #ffff00 - Yellow */
+                    0xb000ff, /* #b000ff - Purple */
+                    0xffffff, /* #ffffff - White */
+                    0x000000  /* #000000 - Black */
+                },
+                .factor = 4.0f
+            },
+            .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
+    /* Add new flags above this line. */
 };
 ```
 
 ### Step 2: Add to the enum
-Next, add a value of your flag to the enum `flag_type_t` (just before `FLAG_TYPE_END`)
+Next, add a new value at the end of the enum `flag_type_t` (just before `FLAG_TYPE_END`). If you've added more than
+new flag, be sure their order here matches their order in the `flags` array!
+
 ``` c
 /* Patterns enum. */
 typedef enum flag_type_e
@@ -63,32 +71,8 @@ typedef enum flag_type_e
 } flag_type_t;
 ```
 
-### Step 3: Handle in the `get_pattern` function
-Add a `case` to the `switch` in the function.
-``` c
-    switch (flag_type) {
-        case FLAG_TYPE_RAINBOW:
-            return &rainbow;
-
-        case FLAG_TYPE_TRANS:
-            return &transgender;
-
-        ...
-
-        case FLAG_TYPE_ASEXUAL:
-            return &asexual;
-
-        case FLAG_TYPE_YOUR_NEW_FLAG:
-            return &your_new_flag;
-
-        default:
-            return NULL;
-    }
-
-```
-
-### Step 4: Add in the `README.md` and help string.
-**Pay attension to the number it gets from the enum!**
+### Step 3: Add in the `README.md` and help string.
+**Pay attention to the number it gets from the enum!**
 
 `main.c`
 ``` c
@@ -108,7 +92,7 @@ Extend the line for `--flag` under `Usage` the same way as in the `main.c`.
 
 *Note that in the readme it is a single line.*
 
-### Step 5: Pull request :)
+### Step 4: Pull request :)
 
 ## Compiling
 to compile with gcc: `$ gcc main.c -lm -o queercat`  

--- a/main.c
+++ b/main.c
@@ -139,242 +139,245 @@ get_color_f get_color_stripes;
 
 
 /* *** Flags *********************************************************/
-const pattern_t rainbow = {
-    .name = "rainbow",
-    .ansii_pattern = {
-        .codes_count = 30,
-        .ansii_codes = { 39, 38, 44, 43, 49, 48, 84, 83, 119, 118, 154, 148, 184, 178,
-        214, 208, 209, 203, 204, 198, 199, 163, 164, 128, 129, 93, 99, 63, 69, 33 }
-    },
-    .color_pattern = { 0 },
-    .get_color = get_color_rainbow
-};
-
-const pattern_t transgender = {
-    .name = "transgender",
-    .ansii_pattern = {
-        .codes_count = 10,
-        .ansii_codes = {117, 117,  225, 225,  255, 255,  225, 225,  117, 117}
-    },
-    .color_pattern = {
-        .stripes_count = 5,
-        .stripes_colors = {
-            0x55cdfc, /* #55cdfd - Blue */
-            0xf7a8b8, /* #f7a8b8 - Pink */
-            0xffffff, /* #ffffff - White */
-            0xf7a8b8, /* #f7a8b8 - Pink */
-            0x55cdfc  /* #55cdfc - Blue */
+const pattern_t flags[] = {
+    {
+        .name = "rainbow",
+        .ansii_pattern = {
+            .codes_count = 30,
+            .ansii_codes = { 39, 38, 44, 43, 49, 48, 84, 83, 119, 118, 154, 148, 184, 178,
+                214, 208, 209, 203, 204, 198, 199, 163, 164, 128, 129, 93, 99, 63, 69, 33 }
         },
-        .factor = 4.0f
+        .color_pattern = { 0 },
+        .get_color = get_color_rainbow
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t nonbinary = {
-    .name = "nonbinary",
-    .ansii_pattern = {
-        .codes_count = 8,
-        .ansii_codes = {226, 226, 255, 255, 93, 93, 234, 234}
-    },
-    .color_pattern = {
-        .stripes_count = 4,
-        .stripes_colors = {
-            0xffff00, /* #ffff00 - Yellow */
-            0xb000ff, /* #b000ff - Purple */
-            0xffffff, /* #ffffff - White */
-            0x000000  /* #000000 - Black */
+    {
+        .name = "transgender",
+        .ansii_pattern = {
+            .codes_count = 10,
+            .ansii_codes = {117, 117,  225, 225,  255, 255,  225, 225,  117, 117}
         },
-        .factor = 4.0f
+        .color_pattern = {
+            .stripes_count = 5,
+            .stripes_colors = {
+                0x55cdfc, /* #55cdfd - Blue */
+                0xf7a8b8, /* #f7a8b8 - Pink */
+                0xffffff, /* #ffffff - White */
+                0xf7a8b8, /* #f7a8b8 - Pink */
+                0x55cdfc  /* #55cdfc - Blue */
+            },
+            .factor = 4.0f
+        },
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t lesbian = {
-    .name = "lesbian",
-    .ansii_pattern = {
-        .codes_count = 5,
-        .ansii_codes = {196, 208, 255, 170, 128}
-    },
-    .color_pattern = {
-        .stripes_count = 5,
-        .stripes_colors = {
-            0xff0000, /* #ff0000 - Red */
-            0xff993f, /* #ff993f - Orange */
-            0xffffff, /* #ffffff - White */
-            0xff8cbd, /* #ff8cbd - Pink */
-            0xff4284  /* #ff4284 - Purple */
+    {
+        .name = "nonbinary",
+        .ansii_pattern = {
+            .codes_count = 8,
+            .ansii_codes = {226, 226, 255, 255, 93, 93, 234, 234}
         },
-        .factor = 2.0f
+        .color_pattern = {
+            .stripes_count = 4,
+            .stripes_colors = {
+                0xffff00, /* #ffff00 - Yellow */
+                0xb000ff, /* #b000ff - Purple */
+                0xffffff, /* #ffffff - White */
+                0x000000  /* #000000 - Black */
+            },
+            .factor = 4.0f
+        },
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t gay = {
-    .name = "gay",
-    .ansii_pattern = {
-        .codes_count = 7,
-        .ansii_codes = {36, 49, 121, 255, 117, 105, 92}
-    },
-    .color_pattern = {
-        .stripes_count = 5,
-        .stripes_colors = {
-            0x00b685, /* #00b685 - Teal */
-            0x6bffb6, /* #6bffb6 - Green */
-            0xffffff, /* #ffffff - White */
-            0x8be1ff, /* #8be1ff - Blue */
-            0x8e1ae1  /* #8e1ae1 - Purple */
+    {
+        .name = "lesbian",
+        .ansii_pattern = {
+            .codes_count = 5,
+            .ansii_codes = {196, 208, 255, 170, 128}
         },
-        .factor = 6.0f
+        .color_pattern = {
+            .stripes_count = 5,
+            .stripes_colors = {
+                0xff0000, /* #ff0000 - Red */
+                0xff993f, /* #ff993f - Orange */
+                0xffffff, /* #ffffff - White */
+                0xff8cbd, /* #ff8cbd - Pink */
+                0xff4284  /* #ff4284 - Purple */
+            },
+            .factor = 2.0f
+        },
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t pansexual = {
-    .name = "pansexual",
-    .ansii_pattern = {
-        .codes_count = 9,
-        .ansii_codes = {200, 200, 200,  227, 227, 227,  45, 45, 45}
-    },
-    .color_pattern = {
-        .stripes_count = 3,
-        .stripes_colors = {
-            0xff3388, /* #ff3388 - Pink */
-            0xffea00, /* #ffea00 - Yellow */
-            0x00dbff  /* #00dbff - Cyan */
+    {
+        .name = "gay",
+        .ansii_pattern = {
+            .codes_count = 7,
+            .ansii_codes = {36, 49, 121, 255, 117, 105, 92}
         },
-        .factor = 8.0f
+        .color_pattern = {
+            .stripes_count = 5,
+            .stripes_colors = {
+                0x00b685, /* #00b685 - Teal */
+                0x6bffb6, /* #6bffb6 - Green */
+                0xffffff, /* #ffffff - White */
+                0x8be1ff, /* #8be1ff - Blue */
+                0x8e1ae1  /* #8e1ae1 - Purple */
+            },
+            .factor = 6.0f
+        },
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t bisexual = {
-    .name = "bisexual",
-    .ansii_pattern = {
-        .codes_count = 8,
-        .ansii_codes = {162, 162, 162,  129, 129, 27, 27, 27}
-    },
-    .color_pattern = {
-        .stripes_count = 5,
-        .stripes_colors = {
-            0xff3b7b, /* #ff3b7b - Pink */
-            0xff3b7b, /* #ff3b7b - Pink */
-            0xd06bcc, /* #d06bcc - Purple */
-            0x3b72ff, /* #3b72ff - Blue */
-            0x3b72ff  /* #3b72ff - Blue */
+    {
+        .name = "pansexual",
+        .ansii_pattern = {
+            .codes_count = 9,
+            .ansii_codes = {200, 200, 200,  227, 227, 227,  45, 45, 45}
         },
-        .factor = 4.0f
+        .color_pattern = {
+            .stripes_count = 3,
+            .stripes_colors = {
+                0xff3388, /* #ff3388 - Pink */
+                0xffea00, /* #ffea00 - Yellow */
+                0x00dbff  /* #00dbff - Cyan */
+            },
+            .factor = 8.0f
+        },
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t gender_fluid = {
-    .name = "gender_fluid",
-    .ansii_pattern = {
-        .codes_count = 10,
-        .ansii_codes = {219, 219, 255, 255, 128, 128, 234, 234, 20, 20}
-    },
-    .color_pattern = {
-        .stripes_count = 5,
-        .stripes_colors = {
-            0xffa0bc, /* #ffa0bc - Pink */
-            0xffffff, /* #ffffff - White */
-            0xc600e4, /* #c600e4 - Purple */
-            0x000000, /* #000000 - Black */
-            0x4e3cbb  /* #4e3cbb - Blue */
+    {
+        .name = "bisexual",
+        .ansii_pattern = {
+            .codes_count = 8,
+            .ansii_codes = {162, 162, 162,  129, 129, 27, 27, 27}
         },
-        .factor = 2.0f
+        .color_pattern = {
+            .stripes_count = 5,
+            .stripes_colors = {
+                0xff3b7b, /* #ff3b7b - Pink */
+                0xff3b7b, /* #ff3b7b - Pink */
+                0xd06bcc, /* #d06bcc - Purple */
+                0x3b72ff, /* #3b72ff - Blue */
+                0x3b72ff  /* #3b72ff - Blue */
+            },
+            .factor = 4.0f
+        },
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t asexual = {
-    .name = "asexual",
-    .ansii_pattern = {
-        .codes_count = 8,
-        .ansii_codes = {233, 233, 247, 247, 255, 255, 5, 5}
-    },
-    .color_pattern = {
-        .stripes_count = 4,
-        .stripes_colors = {
-            0x000000, /* #000000 - Black */
-            0xa3a3a3, /* #a3a3a3 - Gray */
-            0xffffff, /* #ffffff - White */
-            0x800080  /* #800080 - Purple */
+    {
+        .name = "gender_fluid",
+        .ansii_pattern = {
+            .codes_count = 10,
+            .ansii_codes = {219, 219, 255, 255, 128, 128, 234, 234, 20, 20}
         },
-        .factor = 4.0f
+        .color_pattern = {
+            .stripes_count = 5,
+            .stripes_colors = {
+                0xffa0bc, /* #ffa0bc - Pink */
+                0xffffff, /* #ffffff - White */
+                0xc600e4, /* #c600e4 - Purple */
+                0x000000, /* #000000 - Black */
+                0x4e3cbb  /* #4e3cbb - Blue */
+            },
+            .factor = 2.0f
+        },
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t unlabeled = {
-    .name = "unlabeled",
-    .ansii_pattern = {
-        .codes_count = 8,
-        .ansii_codes = {194, 194, 255, 255, 195, 195, 223, 223}
-    },
-    .color_pattern = {
-        .stripes_count = 4,
-        .stripes_colors = {
-            0xe6f9e3, /* #e6f9e3 - Green */
-            0xfdfdfb, /* #fdfdfb - White */
-            0xdeeff9, /* #deeff9 - Blue */
-            0xfae1c2  /* #fae1c2 - Orange */
+    {
+        .name = "asexual",
+        .ansii_pattern = {
+            .codes_count = 8,
+            .ansii_codes = {233, 233, 247, 247, 255, 255, 5, 5}
         },
-        .factor = 4.0f
+        .color_pattern = {
+            .stripes_count = 4,
+            .stripes_colors = {
+                0x000000, /* #000000 - Black */
+                0xa3a3a3, /* #a3a3a3 - Gray */
+                0xffffff, /* #ffffff - White */
+                0x800080  /* #800080 - Purple */
+            },
+            .factor = 4.0f
+        },
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
-};
 
-const pattern_t aromantic = {
-    .name = "aromantic",
-    .ansii_pattern = {
-        .codes_count = 10,
-        .ansii_codes = {
-            34, 34,
-            120, 120,
-            255, 255,
-            247, 247,
-            233, 233
-          }
-      },
-    .color_pattern = {
-        .stripes_count = 5,
-        .stripes_colors = {
-            0x3da542, /* #3da542 - Green        */
-            0xa8d379, /* #a8d379 - Light green  */
-            0xffffff, /* #ffffff - White        */
-            0xa9a9a9, /* #a9a9a9 - Grey         */
-            0x000000  /* #000000 - Black        */
+    {
+        .name = "unlabeled",
+        .ansii_pattern = {
+            .codes_count = 8,
+            .ansii_codes = {194, 194, 255, 255, 195, 195, 223, 223}
         },
-        .factor = 1.0f
-      },
-      .get_color = get_color_stripes
-};
-
-const pattern_t aroace = {
-    .name = "aroace",
-    .ansii_pattern = {
-        .codes_count = 10,
-        .ansii_codes = {
-            208, 208,
-            220, 220,
-            255, 255,
-            75, 75,
-            62, 62
-          },
-      },
-      .color_pattern = {
-          .stripes_count = 5,
-          .stripes_colors = {
-              0xe28d00, /* #e28d00 - Orange     */
-              0xeccd00, /* #eccd00 - Yellow     */
-              0xffffff, /* #ffffff - White      */
-              0x62afdd, /* #62afdd - Light blue */
-              0x203756  /* #203756 - Blue       */
+        .color_pattern = {
+            .stripes_count = 4,
+            .stripes_colors = {
+                0xe6f9e3, /* #e6f9e3 - Green */
+                0xfdfdfb, /* #fdfdfb - White */
+                0xdeeff9, /* #deeff9 - Blue */
+                0xfae1c2  /* #fae1c2 - Orange */
+            },
+            .factor = 4.0f
         },
-        .factor = 1.0f
+        .get_color = get_color_stripes
     },
-    .get_color = get_color_stripes
+
+    {
+        .name = "aromantic",
+        .ansii_pattern = {
+            .codes_count = 10,
+            .ansii_codes = {
+                34, 34,
+                120, 120,
+                255, 255,
+                247, 247,
+                233, 233
+            }
+        },
+        .color_pattern = {
+            .stripes_count = 5,
+            .stripes_colors = {
+                0x3da542, /* #3da542 - Green        */
+                0xa8d379, /* #a8d379 - Light green  */
+                0xffffff, /* #ffffff - White        */
+                0xa9a9a9, /* #a9a9a9 - Grey         */
+                0x000000  /* #000000 - Black        */
+            },
+            .factor = 1.0f
+        },
+        .get_color = get_color_stripes
+    },
+
+    {
+        .name = "aroace",
+        .ansii_pattern = {
+            .codes_count = 10,
+            .ansii_codes = {
+                208, 208,
+                220, 220,
+                255, 255,
+                75, 75,
+                62, 62
+            },
+        },
+        .color_pattern = {
+            .stripes_count = 5,
+            .stripes_colors = {
+                0xe28d00, /* #e28d00 - Orange     */
+                0xeccd00, /* #eccd00 - Yellow     */
+                0xffffff, /* #ffffff - White      */
+                0x62afdd, /* #62afdd - Light blue */
+                0x203756  /* #203756 - Blue       */
+            },
+            .factor = 1.0f
+        },
+        .get_color = get_color_stripes
+    },
+    /* Add new flags above this line. */
 };
 
 
@@ -429,46 +432,7 @@ static wint_t helpstr_hack(FILE * _ignored)
 
 static const pattern_t *get_pattern(flag_type_t flag_type)
 {
-    switch (flag_type) {
-        case FLAG_TYPE_RAINBOW:
-            return &rainbow;
-
-        case FLAG_TYPE_TRANS:
-            return &transgender;
-
-        case FLAG_TYPE_NB:
-            return &nonbinary;
-
-        case FLAG_TYPE_LESBIAN:
-            return &lesbian;
-
-        case FLAG_TYPE_GAY:
-            return &gay;
-
-        case FLAG_TYPE_PAN:
-            return &pansexual;
-
-        case FLAG_TYPE_BI:
-            return &bisexual;
-
-        case FLAG_TYPE_GENDERFLUID:
-            return &gender_fluid;
-
-        case FLAG_TYPE_ASEXUAL:
-            return &asexual;
-
-        case FLAG_TYPE_UNLABELED:
-            return &unlabeled;
-
-        case FLAG_TYPE_AROMANTIC:
-            return &aromantic;
-
-        case FLAG_TYPE_AROACE:
-            return &aroace;
-
-        default:
-            return NULL;
-    }
+    return &flags[flag_type];
 }
 
 static void mix_colors(uint32_t color1, uint32_t color2, float balance, float factor, color_t *output_color)

--- a/main.c
+++ b/main.c
@@ -37,37 +37,6 @@ typedef enum escape_state_e {
 
 
 /* *** Constants *****************************************************/
-static char helpstr[] = "\n"
-                        "Usage: queercat [-f flag_number][-h horizontal_speed] [-v vertical_speed] [--] [FILES...]\n"
-                        "\n"
-                        "Concatenate FILE(s), or standard input, to standard output.\n"
-                        "With no FILE, or when FILE is -, read standard input.\n"
-                        "\n"
-                        "--flag <d>                , -f <d>: Choose colors to use:\n"
-                        "                                    [rainbow: 0, trans: 1, NB: 2, lesbian: 3,\n"
-                        "                                    gay: 4, pan: 5, bi: 6, genderfluid: 7, asexual: 8,\n"
-                        "                                    unlabeled: 9, aromantic: 10, aroace: 11]\n"
-                        "                                    default is rainbow (0)\n"
-                        "--horizontal-frequency <d>, -h <d>: Horizontal rainbow frequency (default: 0.23)\n"
-                        "  --vertical-frequency <d>, -v <d>: Vertical rainbow frequency (default: 0.1)\n"
-                        "                 --force-color, -F: Force color even when stdout is not a tty\n"
-                        "             --no-force-locale, -l: Use encoding from system locale instead of\n"
-                        "                                    assuming UTF-8\n"
-                        "                      --random, -r: Random colors\n"
-                        "                       --24bit, -b: Output in 24-bit \"true\" RGB mode (slower and\n"
-                        "                                    not supported by all terminals)\n"
-                        "                         --version: Print version and exit\n"
-                        "                            --help: Show this message\n"
-                        "\n"
-                        "Examples:\n"
-                        "  queercat f - g      Output f's contents, then stdin, then g's contents.\n"
-                        "  queercat            Copy standard input to standard output.\n"
-                        "  fortune | queercat  Display a rainbow cookie.\n"
-                        "\n"
-                        "Report queercat bugs to <https://github.com/elsa002/queercat/issues>\n"
-                        "queercat home page: <https://github.com/elsa002/queercat/>\n"
-                        "base for code: <https://github.com/jaseg/lolcat/>\n"
-                        "Original idea: <https://github.com/busyloop/lolcat/>\n";
 
 #define MAX_FLAG_STRIPES (6)
 #define MAX_ANSII_CODES_PER_STRIPE (5)
@@ -112,6 +81,9 @@ typedef struct pattern_s {
     const color_pattern_t color_pattern;
     get_color_f *get_color;
 } pattern_t;
+
+/* *** A Single Global ***********************************************/
+char *helpstr;
 
 /* *** Pattern Functions *********************************************/
 get_color_f get_color_rainbow;
@@ -368,6 +340,7 @@ static void usage(void);
 static void version(void);
 
 /* Helpers */
+static void build_helpstr();
 static void find_escape_sequences(wint_t current_char, escape_state_t *state);
 static wint_t helpstr_hack(FILE * _ignored);
 
@@ -386,6 +359,77 @@ static void version(void)
 {
     wprintf(L"queercat version 2.0, (c) 2022 elsa002\n");
     exit(0);
+}
+
+static void build_helpstr() {
+    if(helpstr != NULL)
+        return;
+
+    static char helpstr_head[] = "\n"
+        "Usage: queercat [-f flag_number][-h horizontal_speed] [-v vertical_speed] [--] [FILES...]\n"
+        "\n"
+        "Concatenate FILE(s), or standard input, to standard output.\n"
+        "With no FILE, or when FILE is -, read standard input.\n"
+        "\n"
+        "                --flag <d>, -f <d>: Choose colors to use (default: 0 (rainbow)):\n";
+
+    static char helpstr_indent[] = "                                      ";
+
+    static char helpstr_tail[] =
+        "--horizontal-frequency <d>, -h <d>: Horizontal rainbow frequency (default: 0.23)\n"
+        "  --vertical-frequency <d>, -v <d>: Vertical rainbow frequency (default: 0.1)\n"
+        "                 --force-color, -F: Force color even when stdout is not a tty\n"
+        "             --no-force-locale, -l: Use encoding from system locale instead of\n"
+        "                                    assuming UTF-8\n"
+        "                      --random, -r: Random colors\n"
+        "                       --24bit, -b: Output in 24-bit \"true\" RGB mode (slower and\n"
+        "                                    not supported by all terminals)\n"
+        "                         --version: Print version and exit\n"
+        "                            --help: Show this message\n"
+        "\n"
+        "Examples:\n"
+        "  queercat f - g      Output f's contents, then stdin, then g's contents.\n"
+        "  queercat            Copy standard input to standard output.\n"
+        "  fortune | queercat  Display a rainbow cookie.\n"
+        "\n"
+        "Report queercat bugs to <https://github.com/elsa002/queercat/issues>\n"
+        "queercat home page: <https://github.com/elsa002/queercat/>\n"
+        "base for code: <https://github.com/jaseg/lolcat/>\n"
+        "Original idea: <https://github.com/busyloop/lolcat/>\n";
+
+    /* old version of what this generates, for reference:
+     * "                                    [rainbow: 0, trans: 1, NB: 2, lesbian: 3,\n"
+     * "                                    gay: 4, pan: 5, bi: 6, genderfluid: 7, asexual: 8,\n"
+     * "                                    unlabeled: 9, aromantic: 10, aroace: 11]\n"
+     * would be nice to have the dynamic word-wrap back, but that's
+     * more clever than I currently feel like trying to be
+     */
+    const int line_max_len = strlen(helpstr_indent) + MAX_FLAG_NAME_LENGTH + strlen(": 000\n") ;
+    char lines[FLAG_COUNT][line_max_len];
+    size_t lines_total_len = 0;
+
+    for(int i = 0; i < FLAG_COUNT; ++i) {
+        lines_total_len += snprintf(lines[i], line_max_len, "%s%s: %d\n", helpstr_indent, flags[i].name, i);
+    }
+
+    size_t helpstr_len = strlen(helpstr_head) + lines_total_len + strlen(helpstr_tail);
+
+    char *out = malloc(helpstr_len);
+    char *out_pos = out;
+
+    out_pos = mempcpy(out, helpstr_head, strlen(helpstr_head));
+
+    for(int i = 0; i < FLAG_COUNT; ++i) {
+        char* this_line = lines[i];
+        out_pos = mempcpy(out_pos, this_line, strlen(this_line));
+    }
+
+    memcpy(out_pos, helpstr_tail, strlen(helpstr_tail));
+
+    // TODO maybe free() this at some point? should be cleaned up at program exit, but
+    // it feels a bit gross to rely on that... could refactor helpstr_hack to not rely
+    // on helpstr being global maybe?
+    helpstr = out;
 }
 
 static void find_escape_sequences(wint_t current_char, escape_state_t *state)
@@ -513,6 +557,8 @@ int main(int argc, char** argv)
     struct timeval tv;
     gettimeofday(&tv, NULL);
     double offx = (tv.tv_sec % 300) / 300.0;
+
+    build_helpstr();
 
     /* Handle flags. */
     for (i = 1; i < argc; i++) {

--- a/main.c
+++ b/main.c
@@ -113,8 +113,6 @@ typedef struct pattern_s {
     get_color_f *get_color;
 } pattern_t;
 
-typedef size_t flag_type_t;
-
 /* *** Pattern Functions *********************************************/
 get_color_f get_color_rainbow;
 get_color_f get_color_stripes;
@@ -374,7 +372,6 @@ static void find_escape_sequences(wint_t current_char, escape_state_t *state);
 static wint_t helpstr_hack(FILE * _ignored);
 
 /* Colors handling */
-static const pattern_t *get_pattern(flag_type_t flag_type);
 static void mix_colors(uint32_t color1, uint32_t color2, float balance, float factor, color_t *output_color);
 static void print_color(const pattern_t *pattern, color_type_t color_type, int char_index, int line_index, double freq_h, double freq_v, double offx, int rand_offset, int cc);
 
@@ -411,11 +408,6 @@ static wint_t helpstr_hack(FILE * _ignored)
         return c;
     idx = 0;
     return WEOF;
-}
-
-static const pattern_t *get_pattern(flag_type_t flag_type)
-{
-    return &flags[flag_type];
 }
 
 static void mix_colors(uint32_t color1, uint32_t color2, float balance, float factor, color_t *output_color)
@@ -515,7 +507,7 @@ int main(int argc, char** argv)
     color_type_t color_type = COLOR_TYPE_ANSII;
     double freq_h = 0.23;
     double freq_v = 0.1;
-    flag_type_t flag_type = 0; // default to rainbow
+    int flag_type = 0; // default to rainbow
     const pattern_t *pattern;
 
     struct timeval tv;
@@ -527,7 +519,8 @@ int main(int argc, char** argv)
         char* endptr;
         if (!strcmp(argv[i], "-f") || !strcmp(argv[i], "--flag")) {
             if ((++i) < argc) {
-                flag_type = (flag_type_t)strtod(argv[i], &endptr);
+                // TODO? use strtoul instead of strtod?
+                flag_type = (int)strtod(argv[i], &endptr);
                 if (*endptr)
                     usage();
             } else {
@@ -566,10 +559,13 @@ int main(int argc, char** argv)
         }
     }
 
+    /* Get pattern. */
     if (flag_type < 0 || flag_type >= FLAG_COUNT) {
         fprintf(stderr, "Invalid flag: %d\n", flag_type);
         exit(1);
     }
+
+    pattern = &flags[flag_type];
 
     /* Handle randomness. */
     int rand_offset = 0;
@@ -595,9 +591,6 @@ int main(int argc, char** argv)
     } else {
         setlocale(LC_ALL, "");
     }
-
-    /* Get pattern. */
-    pattern = get_pattern(flag_type);
 
     /* For file in inputs. */
     for (char** filename = inputs; filename < inputs_end; filename++) {

--- a/main.c
+++ b/main.c
@@ -113,25 +113,7 @@ typedef struct pattern_s {
     get_color_f *get_color;
 } pattern_t;
 
-/* Patterns enum. */
-typedef enum flag_type_e
-{
-    FLAG_TYPE_INVALID = -1,
-    FLAG_TYPE_RAINBOW = 0,
-    FLAG_TYPE_TRANS,
-    FLAG_TYPE_NB,
-    FLAG_TYPE_LESBIAN,
-    FLAG_TYPE_GAY,
-    FLAG_TYPE_PAN,
-    FLAG_TYPE_BI,
-    FLAG_TYPE_GENDERFLUID,
-    FLAG_TYPE_ASEXUAL,
-    FLAG_TYPE_UNLABELED,
-    FLAG_TYPE_AROMANTIC,
-    FLAG_TYPE_AROACE,
-    FLAG_TYPE_END
-} flag_type_t;
-
+typedef size_t flag_type_t;
 
 /* *** Pattern Functions *********************************************/
 get_color_f get_color_rainbow;
@@ -380,6 +362,7 @@ const pattern_t flags[] = {
     /* Add new flags above this line. */
 };
 
+const int FLAG_COUNT = sizeof(flags)/sizeof(flags[0]);
 
 /* *** Functions Declarations ****************************************/
 /* Info */
@@ -532,7 +515,7 @@ int main(int argc, char** argv)
     color_type_t color_type = COLOR_TYPE_ANSII;
     double freq_h = 0.23;
     double freq_v = 0.1;
-    flag_type_t flag_type = FLAG_TYPE_RAINBOW;
+    flag_type_t flag_type = 0; // default to rainbow
     const pattern_t *pattern;
 
     struct timeval tv;
@@ -583,7 +566,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (flag_type <= FLAG_TYPE_INVALID || flag_type >= FLAG_TYPE_END) {
+    if (flag_type < 0 || flag_type >= FLAG_COUNT) {
         fprintf(stderr, "Invalid flag: %d\n", flag_type);
         exit(1);
     }

--- a/main.c
+++ b/main.c
@@ -361,7 +361,8 @@ static void version(void)
     exit(0);
 }
 
-static void build_helpstr() {
+static void build_helpstr()
+{
     if(helpstr != NULL)
         return;
 


### PR DESCRIPTION
Building upon #10: do a bunch of scary-looking C string manipulation to generate `--help`'s flag list from the compiled-in array, removing the only other place (besides the flag description itself) that needs to be updated to add a new flag.